### PR TITLE
Redesign: cold brutalist, monochrome + deep red

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,18 +1,17 @@
 export default function AboutPage() {
   return (
-    <section className="max-w-3xl space-y-14 md:space-y-16">
-      <header className="fade-up">
-        <p className="font-mono text-[11px] tracking-[0.25em] uppercase text-fg-muted mb-6">
-          About
-        </p>
-        <h1 className="font-display text-5xl md:text-8xl leading-[0.92] tracking-tight">
-          A short <span className="italic text-accent">note</span>.
+    <section className="max-w-3xl space-y-16 md:space-y-20">
+      <header className="drift drift-1">
+        <h1 className="font-display uppercase tracking-tight leading-[0.9] text-5xl md:text-8xl">
+          <span className="block">A short</span>
+          <span className="block">note.</span>
         </h1>
+        <div className="mt-8 h-px w-20 bg-accent" />
       </header>
 
-      <div className="space-y-6 text-lg md:text-xl text-fg/85 leading-relaxed fade-up fade-up-delay-1">
+      <div className="space-y-6 text-lg md:text-xl text-fg/90 leading-relaxed drift drift-2">
         <p>
-          I&rsquo;m Will Brodhead &mdash; Fullstack SWE &amp; Quant at{' '}
+          I&rsquo;m Will Brodhead. I work as a fullstack and quant engineer at{' '}
           <a
             className="underline decoration-1 underline-offset-4 hover:text-accent transition-colors"
             href="https://gsmc.ai"
@@ -24,23 +23,17 @@ export default function AboutPage() {
           . UConn &lsquo;24.
         </p>
         <p>
-          I build complex systems and high-throughput data pipelines in{' '}
-          <span className="font-mono text-base text-accent">Rust</span>,{' '}
-          <span className="font-mono text-base text-accent">C++</span>, and{' '}
-          <span className="font-mono text-base text-accent">Python</span>.
-          Predictive analytics, fintech, and machine learning are my specialties.
+          I write Rust, C++, and Python — mostly high-throughput data
+          pipelines and low-latency systems, with the occasional detour into
+          machine learning when the problem warrants it.
         </p>
-        <p className="text-fg-muted">Based in Stamford, CT.</p>
+        <p className="text-fg-muted">Based in Stamford, Connecticut.</p>
       </div>
 
-      <div className="border-t border-border pt-10 fade-up fade-up-delay-2">
-        <p className="font-mono text-[11px] tracking-[0.25em] uppercase text-fg-muted mb-6">
-          Reach
-        </p>
-        <dl className="grid grid-cols-[8rem_1fr] gap-y-4 font-mono text-sm">
-          <dt className="text-fg-muted text-xs tracking-[0.15em] uppercase pt-1">
-            Email
-          </dt>
+      <div className="pt-10 drift drift-3">
+        <div className="seam mb-10" />
+        <dl className="grid grid-cols-[6rem_1fr] md:grid-cols-[8rem_1fr] gap-y-5 text-sm md:text-base">
+          <dt className="text-fg-muted pt-0.5">Email</dt>
           <dd>
             <a
               href="mailto:brodheadw@gmail.com"
@@ -49,9 +42,7 @@ export default function AboutPage() {
               brodheadw@gmail.com
             </a>
           </dd>
-          <dt className="text-fg-muted text-xs tracking-[0.15em] uppercase pt-1">
-            GitHub
-          </dt>
+          <dt className="text-fg-muted pt-0.5">GitHub</dt>
           <dd>
             <a
               href="https://github.com/brodheadw"
@@ -62,9 +53,7 @@ export default function AboutPage() {
               brodheadw
             </a>
           </dd>
-          <dt className="text-fg-muted text-xs tracking-[0.15em] uppercase pt-1">
-            LinkedIn
-          </dt>
+          <dt className="text-fg-muted pt-0.5">LinkedIn</dt>
           <dd>
             <a
               href="https://linkedin.com/in/brodheadw"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,17 +1,17 @@
 @import "tailwindcss";
 
 @theme inline {
-  --color-bg: #0a0907;
-  --color-bg-elev: #15110d;
-  --color-fg: #ede4d3;
-  --color-fg-muted: #7a7163;
-  --color-border: #221c14;
-  --color-accent: #c8945a;
-  --color-accent-soft: #9a6b3a;
+  --color-bg: #06070a;
+  --color-bg-elev: #0e1015;
+  --color-fg: #d8dade;
+  --color-fg-muted: #5e636b;
+  --color-border: #181c23;
+  --color-accent: #8a1717;
+  --color-accent-soft: #5c1010;
 
-  --font-display: var(--font-instrument-serif);
-  --font-sans: var(--font-inter);
-  --font-mono: var(--font-jetbrains-mono);
+  --font-display: var(--font-display);
+  --font-sans: var(--font-sans);
+  --font-mono: var(--font-mono);
 }
 
 html, body {
@@ -24,27 +24,46 @@ html, body {
 
 ::selection {
   background: var(--color-accent);
-  color: var(--color-bg);
+  color: var(--color-fg);
 }
 
-@keyframes fade-up {
-  from { opacity: 0; transform: translateY(14px); }
-  to { opacity: 1; transform: translateY(0); }
+/* Looming-shadow effect: a heavy darkening band at the top of the viewport,
+   as if something massive overhead is blocking light. Fixed so it stays put
+   while the page scrolls past. */
+.page-shadow {
+  position: fixed;
+  inset: 0 0 auto 0;
+  height: 70vh;
+  pointer-events: none;
+  z-index: 0;
+  background:
+    linear-gradient(
+      to bottom,
+      #000000 0%,
+      #02030600 70%,
+      transparent 100%
+    );
 }
 
-.fade-up {
-  animation: fade-up 0.9s cubic-bezier(0.22, 1, 0.36, 1) both;
+@keyframes drift-in {
+  from { opacity: 0; transform: translateY(20px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
-.fade-up-delay-1 { animation-delay: 0.1s; }
-.fade-up-delay-2 { animation-delay: 0.25s; }
-.fade-up-delay-3 { animation-delay: 0.4s; }
+.drift {
+  animation: drift-in 1.4s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.drift-1 { animation-delay: 0.05s; }
+.drift-2 { animation-delay: 0.25s; }
+.drift-3 { animation-delay: 0.5s; }
+.drift-4 { animation-delay: 0.75s; }
 
 /* CSS-only row expansion on hover via grid-rows trick */
 .row-collapse {
   display: grid;
   grid-template-rows: 0fr;
-  transition: grid-template-rows 0.5s cubic-bezier(0.22, 1, 0.36, 1);
+  transition: grid-template-rows 0.7s cubic-bezier(0.22, 1, 0.36, 1);
 }
 .group:hover .row-collapse,
 .group:focus-within .row-collapse {
@@ -52,4 +71,16 @@ html, body {
 }
 .row-collapse > * {
   overflow: hidden;
+}
+
+/* Thin horizontal rule used as section divider — evokes a panel seam */
+.seam {
+  height: 1px;
+  background: linear-gradient(
+    to right,
+    transparent 0%,
+    var(--color-border) 12%,
+    var(--color-border) 88%,
+    transparent 100%
+  );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,25 +1,24 @@
 import './globals.css'
-import { Instrument_Serif, Inter, JetBrains_Mono } from 'next/font/google'
+import { Archivo_Black, Inter, JetBrains_Mono } from 'next/font/google'
 import Header from '@/components/Header'
 import Footer from '@/components/Footer'
 
-const instrumentSerif = Instrument_Serif({
+const archivoBlack = Archivo_Black({
   weight: '400',
-  style: ['normal', 'italic'],
   subsets: ['latin'],
-  variable: '--font-instrument-serif',
+  variable: '--font-display',
   display: 'swap',
 })
 
 const inter = Inter({
   subsets: ['latin'],
-  variable: '--font-inter',
+  variable: '--font-sans',
   display: 'swap',
 })
 
 const jetbrainsMono = JetBrains_Mono({
   subsets: ['latin'],
-  variable: '--font-jetbrains-mono',
+  variable: '--font-mono',
   display: 'swap',
 })
 
@@ -27,11 +26,10 @@ export const metadata = {
   metadataBase: new URL('https://brodheadw.github.io'),
   title: { default: 'Will Brodhead', template: '%s · Will Brodhead' },
   description:
-    'Fullstack SWE & Quant. Complex systems and high-throughput data pipelines in Rust, C++, and Python.',
+    'Systems and quant engineer. Rust, C++, Python.',
   openGraph: {
     title: 'Will Brodhead',
-    description:
-      'Fullstack SWE & Quant. Complex systems and high-throughput data pipelines in Rust, C++, and Python.',
+    description: 'Systems and quant engineer. Rust, C++, Python.',
     url: 'https://brodheadw.github.io',
     siteName: 'Will Brodhead',
     type: 'website',
@@ -46,10 +44,11 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${instrumentSerif.variable} ${inter.variable} ${jetbrainsMono.variable}`}
+      className={`${archivoBlack.variable} ${inter.variable} ${jetbrainsMono.variable}`}
     >
       <body className="min-h-screen bg-bg text-fg antialiased">
-        <div className="mx-auto max-w-5xl px-6 md:px-10">
+        <div className="page-shadow" aria-hidden />
+        <div className="relative mx-auto max-w-5xl px-6 md:px-10">
           <Header />
           <main className="py-12 md:py-20">{children}</main>
           <Footer />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,37 +3,28 @@ import ProjectRow from '@/components/ProjectRow'
 
 export default function HomePage() {
   return (
-    <div className="space-y-28 md:space-y-36">
-      <section className="pt-4 md:pt-12">
-        <div className="flex items-center justify-between font-mono text-[11px] tracking-[0.25em] uppercase text-fg-muted mb-12 fade-up">
-          <span>Stamford, CT</span>
-          <span>MMXXVI</span>
-        </div>
-
-        <h1 className="font-display tracking-tight leading-[0.9] text-6xl sm:text-7xl md:text-[8.5rem] fade-up fade-up-delay-1">
-          <span className="block">Will Brodhead.</span>
-          <span className="block italic text-fg-muted">Fullstack SWE</span>
-          <span className="block">
-            <span className="italic">&amp;</span>{' '}
-            <span className="text-accent">Quant</span>.
-          </span>
+    <div className="space-y-32 md:space-y-40">
+      <section className="pt-6 md:pt-16">
+        <h1 className="font-display uppercase tracking-tight leading-[0.85] text-6xl sm:text-7xl md:text-[9.5rem] drift drift-1">
+          <span className="block">William</span>
+          <span className="block">Brodhead</span>
         </h1>
 
-        <p className="mt-14 md:mt-16 max-w-2xl text-lg md:text-2xl text-fg/85 leading-snug fade-up fade-up-delay-2">
-          I build complex systems and high-throughput data pipelines in{' '}
-          <span className="font-mono text-base md:text-lg text-accent">Rust</span>
-          ,{' '}
-          <span className="font-mono text-base md:text-lg text-accent">C++</span>
-          , and{' '}
-          <span className="font-mono text-base md:text-lg text-accent">
-            Python
-          </span>
-          . Predictive analytics, fintech, and machine learning are my
-          specialties.
+        <div className="mt-10 md:mt-12 flex items-center gap-4 drift drift-2">
+          <div className="h-px w-12 md:w-20 bg-accent" />
+          <p className="font-display uppercase tracking-[0.15em] text-sm md:text-base">
+            Systems &amp; Quant
+          </p>
+        </div>
+
+        <p className="mt-12 md:mt-14 max-w-2xl text-lg md:text-2xl text-fg/90 leading-snug drift drift-3">
+          I write Rust, C++, and Python — high-throughput data
+          pipelines, low-latency systems, and the occasional machine-learning
+          rabbit hole.
         </p>
 
-        <p className="mt-6 max-w-xl text-fg-muted fade-up fade-up-delay-3">
-          Currently building at{' '}
+        <p className="mt-6 max-w-xl text-fg-muted drift drift-4">
+          Currently at{' '}
           <a
             href="https://gsmc.ai"
             target="_blank"
@@ -42,20 +33,20 @@ export default function HomePage() {
           >
             Global Strategic Minerals Corporation
           </a>
-          .
+          . Stamford, Connecticut.
         </p>
       </section>
 
       <section>
-        <header className="flex items-baseline justify-between border-b border-border pb-3 mb-1">
-          <h2 className="font-mono text-[11px] tracking-[0.25em] uppercase text-fg-muted">
-            Selected Work
+        <div className="flex items-baseline gap-6 mb-2">
+          <h2 className="font-display uppercase tracking-tight text-3xl md:text-5xl">
+            Work
           </h2>
-          <span className="font-mono text-[11px] tracking-[0.25em] uppercase text-fg-muted">
-            {String(projects.length).padStart(2, '0')} /{' '}
+          <div className="seam flex-1 translate-y-[-0.4em]" />
+          <span className="font-mono text-xs text-fg-muted tabular-nums">
             {String(projects.length).padStart(2, '0')}
           </span>
-        </header>
+        </div>
         <ul>
           {projects.map((project, i) => (
             <ProjectRow key={project.id} project={project} index={i + 1} />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,8 +1,8 @@
 export default function Footer() {
   return (
-    <footer className="border-t border-border py-8 mt-12 font-mono text-[11px] tracking-[0.2em] uppercase text-fg-muted">
+    <footer className="border-t border-border py-10 mt-16 text-sm text-fg-muted">
       <div className="flex flex-col gap-3 md:flex-row md:justify-between md:items-center">
-        <span>Stamford, CT — 41°N 73°W</span>
+        <span>Stamford, Connecticut</span>
         <span>© 2026 Will Brodhead</span>
       </div>
     </footer>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,16 +2,16 @@ import Link from 'next/link'
 
 export default function Header() {
   return (
-    <header className="flex items-center justify-between border-b border-border py-5">
+    <header className="flex items-center justify-between border-b border-border py-6">
       <Link
         href="/"
-        className="font-mono text-xs tracking-[0.25em] uppercase text-fg-muted hover:text-accent transition-colors"
+        className="font-display uppercase tracking-tight text-lg md:text-xl hover:text-accent transition-colors"
       >
-        WB <span className="text-fg-muted/40">/</span> brodheadw.github.io
+        Brodhead
       </Link>
-      <nav className="flex items-center gap-6 md:gap-8 font-mono text-[11px] tracking-[0.2em] uppercase text-fg-muted">
+      <nav className="flex items-center gap-6 md:gap-8 text-sm text-fg-muted">
         <Link href="/" className="hover:text-fg transition-colors">
-          Index
+          Work
         </Link>
         <Link href="/about" className="hover:text-fg transition-colors">
           About
@@ -22,7 +22,7 @@ export default function Header() {
           rel="noopener noreferrer"
           className="hover:text-fg transition-colors"
         >
-          GH
+          GitHub
         </a>
         <a
           href="https://linkedin.com/in/brodheadw"
@@ -30,13 +30,13 @@ export default function Header() {
           rel="noopener noreferrer"
           className="hover:text-fg transition-colors"
         >
-          LI
+          LinkedIn
         </a>
         <a
           href="mailto:brodheadw@gmail.com"
           className="hover:text-fg transition-colors"
         >
-          Mail
+          Email
         </a>
       </nav>
     </header>

--- a/src/components/ProjectRow.tsx
+++ b/src/components/ProjectRow.tsx
@@ -11,38 +11,35 @@ export default function ProjectRow({ project, index }: Props) {
   const href = project.liveUrl || project.githubUrl
 
   return (
-    <li className="group border-b border-border">
+    <li className="group border-t border-border last:border-b">
       <Link
         href={href}
         target="_blank"
         rel="noopener noreferrer"
-        className="block py-7 md:py-9"
+        className="block py-7 md:py-10"
       >
-        <div className="flex items-baseline gap-4 md:gap-8">
-          <span className="font-mono text-[11px] tracking-[0.2em] text-fg-muted w-8 shrink-0">
+        <div className="flex items-baseline gap-5 md:gap-10">
+          <span className="font-display text-fg-muted text-xl md:text-3xl tabular-nums w-10 md:w-14 shrink-0 transition-colors duration-500 group-hover:text-accent">
             {String(index).padStart(2, '0')}
           </span>
-          <h3 className="font-display text-3xl md:text-6xl flex-1 leading-none transition-colors duration-300 group-hover:text-accent">
+          <h3 className="font-display uppercase tracking-tight text-3xl md:text-5xl flex-1 leading-[0.95] transition-colors duration-500 group-hover:text-fg">
             {project.title}
           </h3>
           <span className="hidden md:inline font-mono text-[10px] tracking-[0.2em] uppercase text-fg-muted whitespace-nowrap">
             {project.tags.slice(0, 2).join(' · ')}
           </span>
-          <span className="text-fg-muted group-hover:text-accent group-hover:translate-x-1 transition-all duration-300 inline-block">
-            ↗
-          </span>
         </div>
 
         <div className="row-collapse">
           <div>
-            <div className="pt-6 pl-12 md:pl-16 flex flex-col md:flex-row gap-6 md:gap-10">
+            <div className="pt-7 pl-14 md:pl-24 flex flex-col md:flex-row gap-6 md:gap-10">
               {project.image && (
                 <div className="relative w-full md:w-56 h-40 md:h-36 shrink-0 overflow-hidden border border-border">
                   <Image
                     src={project.image}
                     alt={project.title}
                     fill
-                    className="object-cover transition-transform duration-700 group-hover:scale-105"
+                    className="object-cover transition-transform duration-[1200ms] group-hover:scale-105"
                     sizes="(min-width: 768px) 224px, 100vw"
                   />
                 </div>


### PR DESCRIPTION
## Summary

Rebuilds the site around a colder, heavier composition. The previous palette (warm browns + Instrument Serif italic + Roman numerals + "Selected Work" tracked-caps + 41°N 73°W coordinates) was reading as generic AI-template — every tell that a model picks for "tasteful editorial portfolio."

Now: near-black background, bone-white text, a single deep red (`#8a1717`) used sparingly, Archivo Black for display, slower drift-in motion, and a fixed top-of-viewport shadow band that suggests something massive overhead — the "Star Destroyer crawling across the moon" feeling without any literal sci-fi callouts.

**Visual changes**
- Palette: warm brown → cold black + gunmetal + bone-white, one deep oxidized-red accent
- Display font: Instrument Serif (italic, editorial) → Archivo Black (heavy brutalist sans, uppercase)
- Hero: stamped two-line wordmark, single thin red rule, no italic-muted subtitle
- Motion: `fade-up` (0.9s) → `drift` (1.4s), slower easing
- Added `.page-shadow` fixed band — top-of-viewport darkening that reads as a shadow cast from above

**Removed (Vercel-template tells)**
- `MMXXVI` Roman numerals
- `Stamford, CT — 41°N 73°W` geographic coordinates
- Tracked-out mono section labels (`Selected Work`, `About`, `Reach`)
- Italic-muted serif accents (`*Fullstack SWE*`, `a short *note*`)
- `↗` hover arrows
- `WB / brodheadw.github.io` tracked-cap wordmark; `GH / LI / Mail` abbreviated nav

**Copy nudges**
- Hero blurb tightened (cut "predictive analytics, fintech, and machine learning are my specialties")
- Metadata description shortened

## Test plan

- [ ] Pull the branch, `npm install`, `npm run dev`
- [ ] Verify hero renders with Archivo Black, no warm tones, deep red rule visible
- [ ] Verify top-of-viewport shadow band reads as "something looming" not "broken gradient"
- [ ] Hover a project row — confirm slow expand and no `↗` arrow
- [ ] About page renders without italic accent on "note"
- [ ] No console errors, no font fallback flicker
- [ ] Decide if any copy is still too template-y — the *form* is fixed, the *voice* is a separate pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)